### PR TITLE
Add setting to provide additional scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.vaulttec.sonarqube.auth.oidc</groupId>
 	<artifactId>sonar-auth-oidc-plugin</artifactId>
-	<version>1.0.5-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>sonar-plugin</packaging>
 	<name>OpenID Connect Authentication for SonarQube</name>
 	<description>OpenID Connect Authentication for SonarQube</description>

--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
@@ -68,8 +68,6 @@ public class OidcClient {
   private static final Logger LOGGER = Loggers.get(OidcClient.class);
 
   private static final ResponseType RESPONSE_TYPE = new ResponseType(Value.CODE);
-  private static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PROFILE);
-
   private final OidcSettings settings;
 
   public OidcClient(OidcSettings settings) {
@@ -79,7 +77,14 @@ public class OidcClient {
   public AuthenticationRequest getAuthenticationRequest(String callbackUrl, String state) {
     AuthenticationRequest request;
     try {
-      Builder builder = new AuthenticationRequest.Builder(RESPONSE_TYPE, SCOPE, getClientId(), new URI(callbackUrl));
+      String[] additionalScopes = settings.additionalScopes().split(" ");
+      Scope scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PROFILE);
+      
+      for (String additionalScope : additionalScopes) {
+        scope.Add(additionalScope);
+      }
+
+      Builder builder = new AuthenticationRequest.Builder(RESPONSE_TYPE, scope, getClientId(), new URI(callbackUrl));
       request = builder.endpointURI(getProviderMetadata().getAuthorizationEndpointURI()).state(State.parse(state))
           .build();
     } catch (URISyntaxException e) {

--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
@@ -77,11 +77,16 @@ public class OidcClient {
   public AuthenticationRequest getAuthenticationRequest(String callbackUrl, String state) {
     AuthenticationRequest request;
     try {
-      String[] additionalScopes = settings.additionalScopes().split(" ");
       Scope scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PROFILE);
       
-      for (String additionalScope : additionalScopes) {
-        scope.Add(additionalScope);
+      String additionalScopesList = settings.additionalScopes();
+      
+      if (additionalScopesList != null && additionalScopesList != "") {
+        String[] additionalScopes = additionalScopesList.split(" ");
+      
+        for (String additionalScope : additionalScopes) {
+          scope.add(additionalScope);
+        }
       }
 
       Builder builder = new AuthenticationRequest.Builder(RESPONSE_TYPE, scope, getClientId(), new URI(callbackUrl));

--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcSettings.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcSettings.java
@@ -57,6 +57,8 @@ public class OidcSettings {
   private static final String GROUPS_SYNC_CLAIM_NAME = "sonar.auth.oidc.groupsSync.claimName";
   private static final String GROUPS_SYNC_CLAIM_NAME_DEFAULT_VALUE = "groups";
 
+  private static final String ADDITIONAL_SCOPES = "sonar.auth.oidc.additionalScopes";
+  
   private final Settings settings;
 
   public OidcSettings(Settings settings) {
@@ -95,6 +97,10 @@ public class OidcSettings {
 
   public String syncGroupsClaimName() {
     return settings.getString(GROUPS_SYNC_CLAIM_NAME);
+  }
+
+  public String additionalScopes() {
+      return settings.getString(ADDITIONAL_SCOPES);
   }
 
   public static List<PropertyDefinition> definitions() {
@@ -136,7 +142,10 @@ public class OidcSettings {
         PropertyDefinition.builder(GROUPS_SYNC_CLAIM_NAME).name("Groups claim name")
             .description("Name of the claim in the Open ID Connect userinfo holding the user's groups.")
             .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).defaultValue(GROUPS_SYNC_CLAIM_NAME_DEFAULT_VALUE)
-            .index(index++).build());
+            .index(index++).build(),
+        PropertyDefinition.builder(ADDITIONAL_SCOPES).name("Additional scopes")
+            .description("Addtional scopes to pass to the Open ID Connect authorize request.")
+            .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build());
   }
 
 }

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/AbstractOidcTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/AbstractOidcTest.java
@@ -37,10 +37,10 @@ public abstract class AbstractOidcTest {
   protected OidcSettings oidcSettings = new OidcSettings(settings);
 
   protected void setSettings(boolean enabled) {
-    setSettings(enabled, ISSUER_URI);
+    setSettings(enabled, ISSUER_URI, "");
   }
-
-  protected void setSettings(boolean enabled, String issuerUri) {
+  
+  protected void setSettings(boolean enabled, String issuerUri, String additionalScopes) {
     if (enabled) {
       settings.setProperty("sonar.auth.oidc.enabled", true);
       settings.setProperty("sonar.auth.oidc.providerConfiguration", getProviderConfiguration(issuerUri));
@@ -50,6 +50,11 @@ public abstract class AbstractOidcTest {
       settings.setProperty("sonar.auth.oidc.loginStrategy", LOGIN_STRATEGY_DEFAULT_VALUE);
       settings.setProperty("sonar.auth.oidc.groupsSync", true);
       settings.setProperty("sonar.auth.oidc.groupsSync.claimName", "myGroups");
+
+      if (additionalScopes != null && !additionalScopes.isEmpty())
+      {
+        settings.setProperty("sonar.auth.oidc.additionalScopes", additionalScopes);
+      }
     } else {
       settings.setProperty("sonar.auth.oidc.enabled", false);
     }

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/AbstractOidcTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/AbstractOidcTest.java
@@ -40,6 +40,10 @@ public abstract class AbstractOidcTest {
     setSettings(enabled, ISSUER_URI, "");
   }
   
+  protected void setSettings(boolean enabled, String issuerUri) {
+    setSettings(enabled, issuerUri, "");
+  }
+
   protected void setSettings(boolean enabled, String issuerUri, String additionalScopes) {
     if (enabled) {
       settings.setProperty("sonar.auth.oidc.enabled", true);
@@ -50,11 +54,7 @@ public abstract class AbstractOidcTest {
       settings.setProperty("sonar.auth.oidc.loginStrategy", LOGIN_STRATEGY_DEFAULT_VALUE);
       settings.setProperty("sonar.auth.oidc.groupsSync", true);
       settings.setProperty("sonar.auth.oidc.groupsSync.claimName", "myGroups");
-
-      if (additionalScopes != null && !additionalScopes.isEmpty())
-      {
-        settings.setProperty("sonar.auth.oidc.additionalScopes", additionalScopes);
-      }
+      settings.setProperty("sonar.auth.oidc.additionalScopes", additionalScopes);
     } else {
       settings.setProperty("sonar.auth.oidc.enabled", false);
     }

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/AuthOidcPluginTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/AuthOidcPluginTest.java
@@ -35,7 +35,7 @@ public class AuthOidcPluginTest {
   public void test_extensions() throws Exception {
     underTest.define(context);
 
-    assertThat(context.getExtensions()).hasSize(12);
+    assertThat(context.getExtensions()).hasSize(13);
   }
 
   private static class MockContext extends Plugin.Context {

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcClientTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcClientTest.java
@@ -20,6 +20,7 @@ package org.vaulttec.sonarqube.auth.oidc;
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.assertEquals;
+
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -251,12 +252,14 @@ public class OidcClientTest extends AbstractOidcTest {
 
   private OidcClient newSpyOidcClient() {
     setSettings(true);
-    return createSpyOidcClient();
+    OidcClient client = createSpyOidcClient();
+    return client;
   }
 
   private OidcClient newSpyOidcClientWithAdditionalScopes(String scopes) {
     setSettings(true, ISSUER_URI, scopes);
-    return createSpyOidcClient();
+    OidcClient client = createSpyOidcClient();
+    return client;
   }
 
   private OidcClient newSpyOidcClientWithoutProfileInformation() {

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcClientTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcClientTest.java
@@ -70,6 +70,19 @@ public class OidcClientTest extends AbstractOidcTest {
   }
 
   @Test
+  public void getAuthenticationRequestWithAdditionalScopes() throws URISyntaxException {
+    OidcClient underTest = newSpyOidcClientWithAdditionalScopes("groups");
+    AuthenticationRequest request = underTest.getAuthenticationRequest(CALLBACK_URL, STATE);
+    assertEquals("invalid scope", Scope.parse("openid email profile groups"), request.getScope());
+    assertEquals("invalid client id", new ClientID("id"), request.getClientID());
+    assertEquals("invalid state", new State(STATE), request.getState());
+    assertEquals("invalid response type", ResponseType.getDefault(), request.getResponseType());
+    assertEquals("invalid redirect uri", new URI(CALLBACK_URL), request.getRedirectionURI());
+    assertEquals("invalid endpoint uri", new URI(ISSUER_URI).resolve("/protocol/openid-connect/auth"),
+        request.getEndpointURI());
+  }
+
+  @Test
   public void invalidAuthenticationRequestUri() {
     OidcClient underTest = newSpyOidcClient();
     try {
@@ -213,8 +226,7 @@ public class OidcClientTest extends AbstractOidcTest {
     }
   }
 
-  private OidcClient newSpyOidcClient() {
-    setSettings(true);
+  private OidcClient createSpyOidcClient() {
     OidcClient client = spy(new OidcClient(oidcSettings));
     try {
       OIDCTokenResponse tokenResponse = OIDCTokenResponse.parse(JSONObjectUtils.parse(
@@ -235,6 +247,16 @@ public class OidcClientTest extends AbstractOidcTest {
       // ignore
     }
     return client;
+  }
+
+  private OidcClient newSpyOidcClient() {
+    setSettings(true);
+    return createSpyOidcClient();
+  }
+
+  private OidcClient newSpyOidcClientWithAdditionalScopes(String scopes) {
+    setSettings(true, ISSUER_URI, scopes);
+    return createSpyOidcClient();
   }
 
   private OidcClient newSpyOidcClientWithoutProfileInformation() {
@@ -266,5 +288,4 @@ public class OidcClientTest extends AbstractOidcTest {
     }
     return client;
   }
-
 }

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcSettingsTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcSettingsTest.java
@@ -118,8 +118,14 @@ public class OidcSettingsTest {
   }
 
   @Test
+  public void additional_scopes() {
+    settings.setProperty("sonar.auth.oidc.additionalScopes", "groups");
+    assertThat(underTest.additionalScopes()).isEqualTo("groups");
+  }
+
+  @Test
   public void definitions() {
-    assertThat(OidcSettings.definitions()).hasSize(8);
+    assertThat(OidcSettings.definitions()).hasSize(9);
   }
 
   private String getProviderConfiguration() {


### PR DESCRIPTION
The scopes used for the authentication request are currently a fixed value: openid email profile. In order to use the group mapping functionality with Okta, an additional scope, groups, must be provided. This will populate the groups claim in the id_token.

This change will add a new setting called *Additional scopes*. If defined, it will append these to the default scopes listed above.