### PR TITLE
Fix readme for setting sonar.core.serverBaseURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ This plugin enables users to automatically be sign up and authenticated on a Son
 ### Server Base URL
 
 `Server base URL` property must be set either by setting the
-URL from SonarQube administration page (General -\> Server base URL) or
-through setting `sonar.core.serverBaseURL` key value in the `sonar.properties`
-file.
+URL from SonarQube administration page (General -\> Server base URL).
 
 **In this URL no trailing slash is allowed!** Otherwise the redirects from the identity provider back to the SonarQube server are not created correctly.
 


### PR DESCRIPTION
The key  `sonar.core.serverBaseURL` can only be set through the UI. Only settings found in the file `sonar.properties` can be set in this file. Server-related settings that show up in the UI can only be set through the UI.

Not sure about sonarqube v6.7.1, but failed to set in sonarqube >= v6.7.6