### PR TITLE
Check if the groups claim is in the ID token response

### DIFF
--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
@@ -128,7 +128,8 @@ public class OidcClient {
       throw new IllegalStateException("Parsing ID token failed", e);
     }
 
-    if ((userInfo.getName() == null) && (userInfo.getPreferredUsername() == null)) {
+    if (((userInfo.getName() == null) && (userInfo.getPreferredUsername() == null)) ||
+        userInfo.getClaim(config.syncGroupsClaimName()) == null) {
       UserInfoResponse userInfoResponse = getUserInfoResponse(oidcTokens.getBearerAccessToken());
       if (userInfoResponse instanceof UserInfoErrorResponse) {
         ErrorObject errorObject = ((UserInfoErrorResponse) userInfoResponse).getErrorObject();


### PR DESCRIPTION
Some OIDC providers - like Okta - do not encode the groups claim into the token response by default, so the userinfo endpoint needs to be called.