### PR TITLE
Add necessary jose-jwt dependency to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 		<sonar.pluginKey>authoidc</sonar.pluginKey>
 		<sonar-plugin-api.version>7.4</sonar-plugin-api.version>
 		<nimbusds-oidc-sdk.version>6.23</nimbusds-oidc-sdk.version>
+		<nimbusds-jose-jwt.version>8.21</nimbusds-jose-jwt.version>
 
 		<license.name>AL2</license.name>
 		<license.owner>Torsten Juergeleit</license.owner>
@@ -149,6 +150,11 @@
 			<groupId>com.nimbusds</groupId>
 			<artifactId>oauth2-oidc-sdk</artifactId>
 			<version>${nimbusds-oidc-sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.nimbusds</groupId>
+			<artifactId>nimbus-jose-jwt</artifactId>
+			<version>${nimbusds-jose-jwt.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>


### PR DESCRIPTION
nimbusds-jose-jwt added breaking changes in v9.x.  Because jose-jwt is not explicitly listed in the pom.xml file, the maven build pulls in v9 automatically when current code will only function with v8.x.  Without this change, the plugin does not build.  See https://connect2id.com/blog/nimbus-jose-jwt-9 for additional details.